### PR TITLE
do not set storageClass on values.yml

### DIFF
--- a/sftpgo/values.yaml
+++ b/sftpgo/values.yaml
@@ -332,4 +332,3 @@ persistence:
     resources:
       requests:
         storage: 5Gi
-    storageClassName: premium-rwo


### PR DESCRIPTION
This allow people to be able to deploy sftpgo without having to override the storageClass

[Setting the storageClass is not mandatory](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1), because controller will take the default one.