### PR TITLE
Add serviceMonitor for sftpgo

### DIFF
--- a/sftpgo/templates/service.yaml
+++ b/sftpgo/templates/service.yaml
@@ -73,6 +73,7 @@ spec:
       appProtocol: http
       {{- end }}
     {{- end }}
+    {{- if .Values.monitoring.enabled }}
     - name: telemetry
       port: 10000
       targetPort: telemetry
@@ -80,6 +81,7 @@ spec:
       {{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion }}
       appProtocol: http
       {{- end }}
+    {{- end }}
   selector:
     {{- include "sftpgo.selectorLabels" . | nindent 4 }}
 

--- a/sftpgo/templates/servicemonitor.yaml
+++ b/sftpgo/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.monitoring.enabled .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "sftpgo.fullname" . }}
+  labels:
+    {{- include "sftpgo.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "sftpgo.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: telemetry
+      path: /metrics
+      interval: 30s
+{{- end }}

--- a/sftpgo/values.yaml
+++ b/sftpgo/values.yaml
@@ -333,3 +333,10 @@ persistence:
       requests:
         storage: 5Gi
     storageClassName: premium-rwo
+
+monitoring:
+  # -- Add the port 10000 to the service to expose telemetry endpoints
+  enabled: true
+  serviceMonitor:
+    # -- Enable Service Monitor for Prometheus Operator
+    enabled: false


### PR DESCRIPTION
with servicemonitor prometheus will be able to discover the metrics exposed on the pod.