### PR TITLE
Add extraPorts to services templates

### DIFF
--- a/sftpgo/templates/service.yaml
+++ b/sftpgo/templates/service.yaml
@@ -80,6 +80,9 @@ spec:
       {{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion }}
       appProtocol: http
       {{- end }}
+    {{- with .Values.service.extraPorts }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   selector:
     {{- include "sftpgo.selectorLabels" . | nindent 4 }}
 
@@ -159,6 +162,9 @@ spec:
       {{- if semverCompare ">=1.20-0" $.Capabilities.KubeVersion.GitVersion }}
       appProtocol: http
       {{- end }}
+    {{- end }}
+    {{- with $service.extraPorts }}
+      {{- toYaml . | nindent 4 }}
     {{- end }}
   selector:
     {{- include "sftpgo.selectorLabels" $ | nindent 4 }}

--- a/sftpgo/values.yaml
+++ b/sftpgo/values.yaml
@@ -157,6 +157,9 @@ service:
       # -- (int) REST API node port (when applicable).
       nodePort:
 
+  # -- (list) Additional ports to be added to the service
+  extraPorts: []
+
   # -- Route external traffic to node-local or cluster-wide endoints.
   # Useful for [preserving the client source IP](https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip).
   externalTrafficPolicy:


### PR DESCRIPTION
This simple change adds the ability to specify extraPorts on your services. I needed this to expose the port range 50000–50009 so that FTP passive mode would work.