### PR TITLE
fix: Allow image tag to contain digest

### DIFF
--- a/sftpgo/templates/_helpers.tpl
+++ b/sftpgo/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 helm.sh/chart: {{ include "sftpgo.chart" . }}
 {{ include "sftpgo.selectorLabels" . }}
 {{- if .Values.image.tag }}
-app.kubernetes.io/version: {{ .Values.image.tag | trimPrefix "v" | quote }}
+app.kubernetes.io/version: {{ regexReplaceAll "[^-A-Za-z0-9_.]" .Values.image.tag "_" | trimPrefix "v" | trunc 63 | quote }}
 {{- else if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}


### PR DESCRIPTION
This change allows for the image tag to contain the digest. Currently this is not possible as the tag is added as label and labels may not contain ':' or '@' nor exceed 63 characters. This PR fixes this by replacing invalid characters and truncating beyond 63 characters of the tag for the label. This fix shouldn't change the behavior of the label for tags without digest.

The label created after the fix for tag `latest@sha256:8d7a1bf44226f2fbcb232edded836ca83a5c13c694575067f11322e19e2a7a0f` is `app.kubernetes.io/version: latest_sha256_8d7a1bf44226f2fbcb232edded836ca83a5c13c694575067f`.