### PR TITLE
allow to customize container ports

### DIFF
--- a/sftpgo/templates/deployment.yaml
+++ b/sftpgo/templates/deployment.yaml
@@ -59,27 +59,22 @@ spec:
           env:
             {{- if .Values.sftpd.enabled }}
             - name: SFTPGO_SFTPD__BINDINGS__0__PORT
-              value: "2022"
-            - name: SFTPGO_SFTPD__BINDINGS__0__ADDRESS
-              value: "0.0.0.0"
+              value: "{{ .Values.sftpd.port}}"
+            {{- else}}
+            - name: SFTPGO_SFTPD__BINDINGS__0__PORT
+              value: "0"
             {{- end }}
             {{- if .Values.ftpd.enabled }}
             - name: SFTPGO_FTPD__BINDINGS__0__PORT
-              value: "2021"
-            - name: SFTPGO_FTPD__BINDINGS__0__ADDRESS
-              value: "0.0.0.0"
+              value: "{{ .Values.ftpd.port}}"
             {{- end }}
             {{- if .Values.webdavd.enabled }}
             - name: SFTPGO_WEBDAVD__BINDINGS__0__PORT
-              value: "8081"
-            - name: SFTPGO_WEBDAVD__BINDINGS__0__ADDRESS
-              value: "0.0.0.0"
+              value: "{{ .Values.webdavd.port}}"
             {{- end }}
             {{- if .Values.httpd.enabled }}
             - name: SFTPGO_HTTPD__BINDINGS__0__PORT
-              value: "8080"
-            - name: SFTPGO_HTTPD__BINDINGS__0__ADDRESS
-              value: "0.0.0.0"
+              value: "{{ .Values.httpd.port}}"
             {{- else }}
             - name: SFTPGO_HTTPD__BINDINGS__0__PORT
               value: "0"
@@ -87,7 +82,7 @@ spec:
             - name: SFTPGO_TELEMETRY__BIND_PORT
               value: "10000"
             - name: SFTPGO_TELEMETRY__BIND_ADDRESS
-              value: "0.0.0.0"
+              value: ""
             {{- with .Values.envVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -102,22 +97,22 @@ spec:
           ports:
             {{- if .Values.sftpd.enabled }}
             - name: sftp
-              containerPort: 2022
+              containerPort: {{ .Values.sftpd.port}}
               protocol: TCP
             {{- end }}
             {{- if .Values.ftpd.enabled }}
             - name: ftp
-              containerPort: 2021
+              containerPort: {{ .Values.ftpd.port}}
               protocol: TCP
             {{- end }}
             {{- if .Values.webdavd.enabled }}
             - name: webdav
-              containerPort: 8081
+              containerPort: {{ .Values.webdavd.port}}
               protocol: TCP
             {{- end }}
             {{- if .Values.httpd.enabled }}
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.httpd.port}}
               protocol: TCP
             {{- end }}
             - name: telemetry

--- a/sftpgo/templates/deployment.yaml
+++ b/sftpgo/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
             {{- if .Values.ftpd.enabled }}
             - name: SFTPGO_FTPD__BINDINGS__0__PORT
               value: "{{ .Values.ftpd.port}}"
+            - name: SFTPGO_FTPD__PASSIVE_PORT_RANGE__START
+              value: "{{ .Values.service.ports.ftp.passiveRange.start }}"
+            - name: SFTPGO_FTPD__PASSIVE_PORT_RANGE__END
+              value: "{{ .Values.service.ports.ftp.passiveRange.end }}"
             {{- end }}
             {{- if .Values.webdavd.enabled }}
             - name: SFTPGO_WEBDAVD__BINDINGS__0__PORT

--- a/sftpgo/templates/service.yaml
+++ b/sftpgo/templates/service.yaml
@@ -51,6 +51,15 @@ spec:
       {{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.GitVersion }}
       appProtocol: ftp
       {{- end }}
+    {{- $start := int .Values.service.ports.ftp.passiveRange.start }}
+    {{- $end := int (add .Values.service.ports.ftp.passiveRange.end 1) }}
+    {{- range $port := untilStep $start $end 1 }}
+    - name: ftp-passive-{{ $port }}
+      port: {{ $port }}
+      targetPort: {{ $port }}
+      protocol: TCP
+      appProtocol: ftp
+    {{- end }}
     {{- end }}
     {{- if .Values.webdavd.enabled }}
     - name: webdav

--- a/sftpgo/values.yaml
+++ b/sftpgo/values.yaml
@@ -31,17 +31,29 @@ sftpd:
   # -- Enable SFTP service.
   enabled: true
 
+  # -- Container SFTP port. Set to 0 to disable the service. The 'enabled' flag may be removed in the future in favor of this setting.
+  port: 2022
+
 ftpd:
   # -- Enable FTP service.
   enabled: false
+
+  # -- Container FTP port. Set to 0 to disable the service. The 'enabled' flag may be removed in the future in favor of this setting.
+  port: 2021
 
 webdavd:
   # -- Enable WebDAV service.
   enabled: false
 
+  # -- Container WebDAV port. Set to 0 to disable the service. The 'enabled' flag may be removed in the future in favor of this setting.
+  port: 8081
+
 httpd:
   # -- Enable HTTP service.
   enabled: true
+
+  # -- Container HTTP port. Set to 0 to disable the service. The 'enabled' flag may be removed in the future in favor of this setting.
+  port: 8080
 
 # -- Application configuration.
 # See the [official documentation](https://docs.sftpgo.com/latest/config-file/).

--- a/sftpgo/values.yaml
+++ b/sftpgo/values.yaml
@@ -164,6 +164,13 @@ service:
       # -- (int) FTP node port (when applicable).
       nodePort:
 
+      passiveRange:
+        # -- FTP passive range start port.
+        start: 50000
+
+        # -- FTP passive range end port.
+        end: 50020
+
     webdav:
       # -- WebDAV service port.
       port: 81


### PR DESCRIPTION
In the future, we can remove the 'enabled' flags entirely. Setting the port gives us more control and also allows to disable the services