### PR TITLE
feat: add image.variant option

### DIFF
--- a/sftpgo/templates/deployment.yaml
+++ b/sftpgo/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s%s" .Chart.AppVersion (ternary (printf "-%s" .Values.image.variant) "" (ne (.Values.image.variant | default "") ""))) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - sftpgo
@@ -185,21 +185,21 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      
+
       {{- $topologyConstraints := list -}}
-      
+
       {{- if kindIs "slice" .Values.topologySpreadConstraints }}
         {{- range $constraint := .Values.topologySpreadConstraints }}
           {{- if not $constraint.labelSelector }}
             {{- $_ := set $constraint "labelSelector" (dict "matchLabels" $selectorLabels) }}
           {{- end }}
           {{- $topologyConstraints = append $topologyConstraints $constraint -}}
-        {{- end }}  
+        {{- end }}
       {{- else if and (kindIs "map" .Values.topologySpreadConstraints) .Values.topologySpreadConstraints.enabled }}
         {{- $legacyConstraint := dict "maxSkew" (default 1 .Values.topologySpreadConstraints.maxSkew) "topologyKey" (default "topology.kubernetes.io/zone" .Values.topologySpreadConstraints.topologyKey) "whenUnsatisfiable" (default "DoNotSchedule" .Values.topologySpreadConstraints.whenUnsatisfiable) "labelSelector" (dict "matchLabels" $selectorLabels) -}}
         {{- $topologyConstraints = append $topologyConstraints $legacyConstraint -}}
       {{- end }}
-      
+
       {{- if not (empty $topologyConstraints) }}
       topologySpreadConstraints:
         {{- toYaml $topologyConstraints | nindent 8 }}

--- a/sftpgo/values.yaml
+++ b/sftpgo/values.yaml
@@ -21,6 +21,10 @@ image:
   # -- Image tag override for the default value (chart appVersion).
   tag: ""
 
+  # -- Override the default image variant. Example: "distroless-slim".
+  # See the [official documentation](https://docs.sftpgo.com/latest/docker/#image-variants).
+  variant: ""
+
 # -- Reference to one or more secrets to be used when [pulling images](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) (from private registries).
 imagePullSecrets: []
 


### PR DESCRIPTION
This enables tracking the chart-provided image version while using a non-default image variant. If image.tag is specified, it overrides the whole tag, including the version. Formatting the file also fixed some whitespace inconsistencies.