### PR TITLE
!chore: uncorrelate service ports creation from app ports

### DIFF
--- a/sftpgo/README.md
+++ b/sftpgo/README.md
@@ -292,14 +292,18 @@ not model port ranges.
 | service.labels | object | `{}` | labels to be added to the service. |
 | service.loadBalancerIP | string | `nil` | Only applies when the service type is LoadBalancer. Load balancer will get created with the IP specified in this field. |
 | service.loadBalancerSourceRanges | list | `[]` | If specified (and supported by the cloud provider), traffic through the load balancer will be restricted to the specified client IPs. Valid values are IP CIDR blocks. |
+| service.ports.ftp.enabled | bool | `true` | Enable FTP port. |
 | service.ports.ftp.nodePort | int | `nil` | FTP node port (when applicable). |
 | service.ports.ftp.passiveRange.end | int | `50020` | FTP passive range end port. |
 | service.ports.ftp.passiveRange.start | int | `50000` | FTP passive range start port. |
 | service.ports.ftp.port | int | `21` | FTP service port. |
+| service.ports.http.enabled | bool | `true`| Enable FTP port. |
 | service.ports.http.nodePort | int | `nil` | REST API node port (when applicable). |
 | service.ports.http.port | int | `80` | REST API service port. |
+| service.ports.sftp.enabled | int | `true` | Enable SFTP port. |
 | service.ports.sftp.nodePort | int | `nil` | SFTP node port (when applicable). |
 | service.ports.sftp.port | int | `22` | SFTP service port. |
+| service.ports.webdav.enabled | int | `true` | Enable WebDAV port. |
 | service.ports.webdav.nodePort | int | `nil` | WebDAV node port (when applicable). |
 | service.ports.webdav.port | int | `81` | WebDAV service port. |
 | service.sessionAffinity | string | `nil` | Enable client IP based session affinity. [More info](https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies) |

--- a/sftpgo/templates/deployment.yaml
+++ b/sftpgo/templates/deployment.yaml
@@ -131,9 +131,15 @@ spec:
               containerPort: 10000
               protocol: TCP
             {{- range $name, $port := .Values.additionalPorts }}
+            {{- $exposeOnContainer := true }}
+            {{- if hasKey $port "exposeOnContainer" }}
+            {{- $exposeOnContainer = $port.exposeOnContainer }}
+            {{- end }}
+            {{- if $exposeOnContainer }}
             - name: {{ $name }}
               containerPort: {{ $port.containerPort }}
               protocol: TCP
+            {{- end }}
             {{- end }}
           livenessProbe:
             httpGet:

--- a/sftpgo/templates/service.yaml
+++ b/sftpgo/templates/service.yaml
@@ -29,7 +29,7 @@ spec:
   sessionAffinity: {{ . }}
   {{- end }}
   ports:
-    {{- if .Values.sftpd.enabled }}
+    {{- if .Values.service.ports.sftp.enabled }}
     - name: sftp
       port: {{ .Values.service.ports.sftp.port }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.ports.sftp.nodePort }}
@@ -39,7 +39,7 @@ spec:
       protocol: TCP
       appProtocol: sftp-ssh
     {{- end }}
-    {{- if .Values.ftpd.enabled }}
+    {{- if .Values.service.ports.ftp.enabled }}
     - name: ftp
       port: {{ .Values.service.ports.ftp.port }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.ports.ftp.nodePort }}
@@ -58,7 +58,7 @@ spec:
       appProtocol: ftp
     {{- end }}
     {{- end }}
-    {{- if .Values.webdavd.enabled }}
+    {{- if .Values.service.ports.webdav.enabled }}
     - name: webdav
       port: {{ .Values.service.ports.webdav.port }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.ports.webdav.nodePort }}
@@ -68,7 +68,7 @@ spec:
       protocol: TCP
       appProtocol: webdav
     {{- end }}
-    {{- if .Values.httpd.enabled }}
+    {{- if .Values.service.ports.http.enabled }}
     - name: http
       port: {{ .Values.service.ports.http.port }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.ports.http.nodePort }}
@@ -122,7 +122,7 @@ spec:
   sessionAffinity: {{ . }}
   {{- end }}
   ports:
-    {{- if and $.Values.sftpd.enabled $service.ports.sftp }}
+    {{- if and $.Values.service.ports.sftp.enabled $service.ports.sftp }}
     - name: sftp
       port: {{ required (printf "SFTP service port is required for service %q" $name) $service.ports.sftp.port }}
       {{- if and (or (eq $service.type "NodePort") (eq $service.type "LoadBalancer")) $service.ports.sftp.nodePort }}
@@ -132,7 +132,7 @@ spec:
       protocol: TCP
       appProtocol: sftp-ssh
     {{- end }}
-    {{- if and $.Values.ftpd.enabled $service.ports.ftp }}
+    {{- if and $.Values.service.ports.ftp.enabled $service.ports.ftp }}
     - name: ftp
       port: {{ required (printf "SFP service port is required for service %q" $name) $service.ports.ftp.port }}
       {{- if and (or (eq $service.type "NodePort") (eq $service.type "LoadBalancer")) $service.ports.ftp.nodePort }}
@@ -153,7 +153,7 @@ spec:
     {{- end }}
     {{- end }}
     {{- end }}
-    {{- if and $.Values.webdavd.enabled $service.ports.webdav }}
+    {{- if and $.Values.service.ports.webdav.enabled $service.ports.webdav }}
     - name: webdav
       port: {{ required (printf "WebDAV service port is required for service %q" $name) $service.ports.webdav.port }}
       {{- if and (or (eq $service.type "NodePort") (eq $service.type "LoadBalancer")) $service.ports.webdav.nodePort }}
@@ -163,7 +163,7 @@ spec:
       protocol: TCP
       appProtocol: webdav
     {{- end }}
-    {{- if and $.Values.httpd.enabled $service.ports.http }}
+    {{- if and $.Values.service.ports.http.enabled $service.ports.http }}
     - name: http
       port: {{ required (printf "HTTP service port is required for service %q" $name) $service.ports.http.port }}
       {{- if and (or (eq $service.type "NodePort") (eq $service.type "LoadBalancer")) $service.ports.http.nodePort }}

--- a/sftpgo/values.yaml
+++ b/sftpgo/values.yaml
@@ -190,6 +190,8 @@ service:
 
   ports:
     sftp:
+      # -- Enable SFTP service port.
+      enabled: true
       # -- SFTP service port.
       port: 22
 
@@ -197,6 +199,8 @@ service:
       nodePort:
 
     ftp:
+      # -- Enable FTP service port.
+      enabled: true
       # -- FTP service port.
       port: 21
 
@@ -211,6 +215,8 @@ service:
         end: 50020
 
     webdav:
+      # -- Enable WebDAV service port.
+      enabled: true
       # -- WebDAV service port.
       port: 81
 
@@ -218,6 +224,8 @@ service:
       nodePort:
 
     http:
+      # -- Enable HTTP service port.
+      enabled: true
       # -- REST API service port.
       port: 80
 
@@ -251,6 +259,7 @@ additionalPorts: {}
   # custom-sftp:
   #   port: 2222           # Service port
   #   containerPort: 22    # Pod port
+  #   exposeOnContainer: true # Whether to expose this port on the container (i.e., add it to the container ports list in the deployment). Defaults to true if not set.
 
 ui:
   ingress:


### PR DESCRIPTION
# Why?

We may need to deploy an application with an application port enabled, but without exposing the corresponding service port.

For example, an application could expose an HTTP port internally while traffic is actually handled through a sidecar proxy in front of that HTTP port. In this case, the application port must remain enabled, but the service port should not be created.

# How?

Add an option to enable or disable the service ports independently from the application ports.
Add an `exposeOnContainer` option to `services.additionalPorts`, allowing custom service ports to be defined without exposing them on the SFTPGo container.